### PR TITLE
Removed the __proto__ property

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,11 @@ var fs = require('fs'),
 
 
 function tryParse(file, json) {
-    var err;
     try {
         return JSON.parse(json);
     } catch (e) {
-        err = new Error(e.message  + ' in ' + file);
-        err.__proto__ = e.__proto__;
-        throw err;
+        e.message += ' in ' + file;
+        throw e;
     }
 }
 


### PR DESCRIPTION
Hi. I was reading your code and saw that you were mutating the Prototype of the err Object from Error to SyntaxError. After reading https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto I tried to make all tests pass without that mutation and came with this solution.
Maybe I'm missing something really obvious for this mutation...
