### PR TITLE
Update dependencies version to the latests one. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ var fs = require('fs'),
     caller = require('caller'),
     strip = require('strip-json-comments');
 
-
 function tryParse(file, json) {
     var err;
     try {
@@ -31,11 +30,5 @@ function shush(file) {
 
     return tryParse(abs, json);
 }
-
-
-//shush.createStream = function () {
-//
-//};
-
 
 module.exports = shush;

--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
   "author": "Erik Toth <totherik@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "tape": "~2.3.2",
-    "istanbul": "~0.2.1"
+    "tape": "~4.6.0",
+    "istanbul": "~0.4.5"
   },
   "dependencies": {
-    "strip-json-comments": "~0.1.1",
-    "caller": "~0.0.1"
+    "strip-json-comments": "~2.0.1",
+    "caller": "~1.0.1"
   },
   "bugs": {
     "url": "https://github.com/totherik/shush/issues"


### PR DESCRIPTION
The main reason of this PR is to update the `caller` module dependency to the latest version. It seems like older versions have `tape` as a dependency (see https://github.com/totherik/caller/blob/v0.0.1/package.json#L24), causing this module to have a larger tree than the necessary.

I also updated all other dependencies.

Let me know what do you think.
